### PR TITLE
세션별 음성파일 디렉토리가 없을 경우 에러

### DIFF
--- a/b1project/homepage/views.py
+++ b/b1project/homepage/views.py
@@ -46,8 +46,9 @@ def voicetest(request):
 
         form = request.POST
         if len(form['text']) and form['voice'] != 'None':
-            for file in os.listdir(audio_dir):
-                os.remove(audio_dir + file)
+            if os.path.isdir(audio_dir):
+                for file in os.listdir(audio_dir):
+                    os.remove(audio_dir + file)
 
             text, voice = form['text'], form['voice']
 


### PR DESCRIPTION
### 개요
세션별 음성파일 디렉토리가 없을 경우 에러 처리

### 내용
기존: 세션별 음성파일 디렉토리가 없는 경우파일을 내부 디렉토리 파일을 조회할 수 없어서 에러
변경: 만약 음성파일 디렉토리가 유효할경우에 내부 디렉토리 파일을 삭제