### PR TITLE
인덱스 에러 수정

### DIFF
--- a/b1project/homepage/views.py
+++ b/b1project/homepage/views.py
@@ -64,7 +64,7 @@ def voicetest(request):
 
             # waiting making the wav file
             # wav file is made only one file
-            while len(os.listdir(audio_dir)):
+            while not len(os.listdir(audio_dir)):
                 pass
 
             # get one wav file


### PR DESCRIPTION
### 개요
인덱스 에러 수정

### 내용
기존
while len(os.listdir(audio_dir)): 의 경우 파일이 없는 경우 while 조건이 False가 되기 때문에 바로 반복문을 빠져나옴

수정
while not len(...):의 경우 파일이 없는경우 while 조건이 True가 되기 때문에 파일 생성후 반복문 빠져나옴